### PR TITLE
テストコードを修正

### DIFF
--- a/api/gacha_test.go
+++ b/api/gacha_test.go
@@ -11,6 +11,9 @@ import (
 	"game-api-gin/config"
 	"game-api-gin/database"
 	"game-api-gin/gmtoken"
+	"game-api-gin/model"
+	"game-api-gin/test"
+	"game-api-gin/util"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -23,7 +26,6 @@ func TestGachaSuite(t *testing.T) {
 
 type GachaSuite struct {
 	suite.Suite
-	uapi       *UserAPI
 	gapi       *GachaAPI
 	auth       *auth.Auth
 	db         *database.GormDatabase
@@ -31,7 +33,8 @@ type GachaSuite struct {
 	ctx        *gin.Context
 	recorder   *httptest.ResponseRecorder
 	token      string
-	privatekey string
+	privateKey string
+	userId     string
 }
 
 func (s *GachaSuite) BeforeTest(string, string) {
@@ -47,8 +50,20 @@ func (s *GachaSuite) BeforeTest(string, string) {
 	t, err := gmtoken.NewGmtokenTx(config)
 	assert.Nil(s.T(), err)
 	s.tx = t
-	s.uapi = &UserAPI{Auth: s.auth, DB: s.db, Tx: s.tx}
 	s.gapi = &GachaAPI{Auth: s.auth, DB: s.db, Tx: s.tx}
+
+	userId, err := util.CreateUUId()
+	assert.Nil(s.T(), err)
+	s.userId = userId
+	privateKey, err := util.CreatePrivateKey()
+	assert.Nil(s.T(), err)
+	s.privateKey = privateKey
+	s.db.CreateUser(model.User{UserID: userId, Name: "mike", PrivateKey: privateKey})
+	token, err := s.auth.CreateToken(userId)
+	assert.Nil(s.T(), err)
+	s.token = token
+	s.gapi.Tx.MintGmtoken(100, privateKey)
+
 	s.T().Log("BeforeTest!!")
 }
 
@@ -57,26 +72,8 @@ func (s *GachaSuite) AfterTest(suiteName, testName string) {
 	s.T().Log("AfterTest!!")
 }
 
-func (s *GachaSuite) SetTokenKey() {
-	s.ctx.Request = httptest.NewRequest("POST", "/user/create", strings.NewReader(`{"name":"satou"}`))
-	s.ctx.Request.Header.Set("Content-Type", "application/json")
-	s.uapi.CreateUser(s.ctx)
-	body, _ := ioutil.ReadAll(s.recorder.Body)
-	var createUserResponse CreateUserResponse
-	json.Unmarshal(body, &createUserResponse)
-	s.token = createUserResponse.Token
-	s.ctx.Request.Header.Set("x-token", s.token)
-
-	userId, err := s.auth.GetUserId(s.ctx)
-	assert.Nil(s.T(), err)
-	user, err := s.db.GetUser(userId)
-	assert.Nil(s.T(), err)
-	s.privatekey = user.PrivateKey
-}
-
 func (s *GachaSuite) Test_DrawGacha() {
-	s.SetTokenKey()
-	s.gapi.Tx.TransferEth(200000000000000000, s.privatekey)
+	s.gapi.Tx.TransferEth(200000000000000000, s.privateKey)
 
 	s.ctx.Request = httptest.NewRequest("POST", "/gacha/draw", strings.NewReader(`{"gacha_id":1,"times":10}`))
 	s.ctx.Request.Header.Set("Content-Type", "application/json")
@@ -85,21 +82,32 @@ func (s *GachaSuite) Test_DrawGacha() {
 	s.gapi.DrawGacha(s.ctx)
 
 	assert.Equal(s.T(), 200, s.recorder.Code)
+
 	body, _ := ioutil.ReadAll(s.recorder.Body)
 	var drawGachaResponse DrawGachaResponse
 	json.Unmarshal(body, &drawGachaResponse)
 	assert.Equal(s.T(), 10, len(drawGachaResponse.Results))
-
-	s.ctx.Request = httptest.NewRequest("GET", "/user/get", nil)
-	s.ctx.Request.Header.Set("Content-Type", "application/json")
-	s.ctx.Request.Header.Set("x-token", s.token)
-
-	s.uapi.GetUser(s.ctx)
-
-	body, _ = ioutil.ReadAll(s.recorder.Body)
-	var getUserResponse GetUserResponse
-	json.Unmarshal(body, &getUserResponse)
-	assert.Equal(s.T(), 90, getUserResponse.GmtokenBalance)
+	var gachaResults []model.GachaResult
+	for i := 1; i < 10; i++ {
+		gachaResults = append(gachaResults, drawGachaResponse.Results[i])
+	}
+	var characterIds []string
+	s.db.DB.Table("gacha_characters").Select("gacha_character_id").Where("gacha_id = ?", 1).Scan(&characterIds)
+	for _, v := range gachaResults {
+		contains := test.Contains(characterIds, v.CharacterID)
+		assert.Equal(s.T(), true, contains)
+	}
+	var characterNames []string
+	s.db.DB.Table("gacha_characters").Select("characters.character_name").
+		Joins("join characters on gacha_characters.character_id = characters.id").
+		Where("gacha_id = ?", 1).Scan(&characterNames)
+	for _, v := range gachaResults {
+		contains := test.Contains(characterNames, v.Name)
+		assert.Equal(s.T(), true, contains)
+	}
+	_, bal, err := s.tx.GetAddressBalance(s.privateKey)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 90, bal)
 }
 
 func (s *GachaSuite) Test_DrawGacha_WithoutEnoughEth() {
@@ -113,9 +121,11 @@ func (s *GachaSuite) Test_DrawGacha_WithoutEnoughEth() {
 }
 
 func (s *GachaSuite) Test_DrawGacha_ByInvalidToken() {
+	s.gapi.Tx.TransferEth(200000000000000000, s.privateKey)
+
 	s.ctx.Request = httptest.NewRequest("POST", "/gacha/draw", strings.NewReader(`{"gacha_id":1,"times":10}`))
 	s.ctx.Request.Header.Set("Content-Type", "application/json")
-	s.ctx.Request.Header.Set("x-token", "InvalidToken")
+	s.ctx.Request.Header.Set("x-token", s.token+"InvalidToken")
 
 	s.gapi.DrawGacha(s.ctx)
 
@@ -123,6 +133,8 @@ func (s *GachaSuite) Test_DrawGacha_ByInvalidToken() {
 }
 
 func (s *GachaSuite) Test_DrawGacha_ByInvalidGachaID() {
+	s.gapi.Tx.TransferEth(200000000000000000, s.privateKey)
+
 	s.ctx.Request = httptest.NewRequest("POST", "/gacha/draw", strings.NewReader(`{"gacha_id":10,"times":10}`))
 	s.ctx.Request.Header.Set("Content-Type", "application/json")
 	s.ctx.Request.Header.Set("x-token", s.token)
@@ -133,6 +145,8 @@ func (s *GachaSuite) Test_DrawGacha_ByInvalidGachaID() {
 }
 
 func (s *GachaSuite) Test_DrawGacha_ByZeroTimes() {
+	s.gapi.Tx.TransferEth(200000000000000000, s.privateKey)
+
 	s.ctx.Request = httptest.NewRequest("POST", "/gacha/draw", strings.NewReader(`{"gacha_id":1,"times":0}`))
 	s.ctx.Request.Header.Set("Content-Type", "application/json")
 	s.ctx.Request.Header.Set("x-token", s.token)
@@ -143,6 +157,8 @@ func (s *GachaSuite) Test_DrawGacha_ByZeroTimes() {
 }
 
 func (s *GachaSuite) Test_DrawGacha_ByMinusTimes() {
+	s.gapi.Tx.TransferEth(200000000000000000, s.privateKey)
+
 	s.ctx.Request = httptest.NewRequest("POST", "/gacha/draw", strings.NewReader(`{"gacha_id":1,"times":-10}`))
 	s.ctx.Request.Header.Set("Content-Type", "application/json")
 	s.ctx.Request.Header.Set("x-token", s.token)
@@ -153,6 +169,8 @@ func (s *GachaSuite) Test_DrawGacha_ByMinusTimes() {
 }
 
 func (s *GachaSuite) Test_DrawGacha_ByExcessiveTimes() {
+	s.gapi.Tx.TransferEth(200000000000000000, s.privateKey)
+
 	s.ctx.Request = httptest.NewRequest("POST", "/gacha/draw", strings.NewReader(`{"gacha_id":1,"times":1000}`))
 	s.ctx.Request.Header.Set("Content-Type", "application/json")
 	s.ctx.Request.Header.Set("x-token", s.token)

--- a/api/user_test.go
+++ b/api/user_test.go
@@ -11,7 +11,10 @@ import (
 	"game-api-gin/config"
 	"game-api-gin/database"
 	"game-api-gin/gmtoken"
+	"game-api-gin/model"
+	"game-api-gin/util"
 
+	"github.com/dgrijalva/jwt-go"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -23,13 +26,15 @@ func TestUserSuite(t *testing.T) {
 
 type UserSuite struct {
 	suite.Suite
-	uapi     *UserAPI
-	auth     *auth.Auth
-	db       *database.GormDatabase
-	tx       *gmtoken.GmtokenTx
-	ctx      *gin.Context
-	recorder *httptest.ResponseRecorder
-	token    string
+	uapi       *UserAPI
+	auth       *auth.Auth
+	db         *database.GormDatabase
+	tx         *gmtoken.GmtokenTx
+	ctx        *gin.Context
+	recorder   *httptest.ResponseRecorder
+	token      string
+	privateKey string
+	userId     string
 }
 
 func (s *UserSuite) BeforeTest(string, string) {
@@ -46,6 +51,18 @@ func (s *UserSuite) BeforeTest(string, string) {
 	assert.Nil(s.T(), err)
 	s.tx = t
 	s.uapi = &UserAPI{Auth: s.auth, DB: s.db, Tx: s.tx}
+
+	userId, err := util.CreateUUId()
+	assert.Nil(s.T(), err)
+	s.userId = userId
+	privateKey, err := util.CreatePrivateKey()
+	assert.Nil(s.T(), err)
+	s.privateKey = privateKey
+	s.db.CreateUser(model.User{UserID: userId, Name: "mike", PrivateKey: privateKey})
+	token, err := s.auth.CreateToken(userId)
+	assert.Nil(s.T(), err)
+	s.token = token
+
 	s.T().Log("BeforeTest!!")
 }
 
@@ -66,6 +83,19 @@ func (s *UserSuite) Test_CreateUser() {
 	s.uapi.CreateUser(s.ctx)
 
 	assert.Equal(s.T(), 200, s.recorder.Code)
+
+	body, _ := ioutil.ReadAll(s.recorder.Body)
+	var createUserResponse CreateUserResponse
+	json.Unmarshal(body, &createUserResponse)
+	token, err := s.auth.VerifyToken(createUserResponse.Token)
+	assert.Nil(s.T(), err)
+	claims := token.Claims.(jwt.MapClaims)
+	userId := claims["userId"].(string)
+	var privateKey string
+	s.db.DB.Table("users").Select("private_key").Where("user_id = ?", userId).Scan(&privateKey)
+	_, bal, err := s.tx.GetAddressBalance(privateKey)
+	assert.Nil(s.T(), err)
+	assert.Equal(s.T(), 100, bal)
 }
 
 func (s *UserSuite) Test_CreateUser_ByIntName() {
@@ -86,18 +116,7 @@ func (s *UserSuite) Test_CreateUser_ByNil() {
 	assert.Equal(s.T(), 400, s.recorder.Code)
 }
 
-func (s *UserSuite) SetToken() {
-	s.ctx.Request = httptest.NewRequest("POST", "/user/create", strings.NewReader(`{"name":"mike"}`))
-	s.ctx.Request.Header.Set("Content-Type", "application/json")
-	s.uapi.CreateUser(s.ctx)
-	body, _ := ioutil.ReadAll(s.recorder.Body)
-	var createUserResponse CreateUserResponse
-	json.Unmarshal(body, &createUserResponse)
-	s.token = createUserResponse.Token
-}
-
 func (s *UserSuite) Test_GetUser() {
-	s.SetToken()
 	s.ctx.Request = httptest.NewRequest("GET", "/user/get", nil)
 	s.ctx.Request.Header.Set("Content-Type", "application/json")
 	s.ctx.Request.Header.Set("x-token", s.token)
@@ -105,17 +124,20 @@ func (s *UserSuite) Test_GetUser() {
 	s.uapi.GetUser(s.ctx)
 
 	assert.Equal(s.T(), 200, s.recorder.Code)
+
 	body, _ := ioutil.ReadAll(s.recorder.Body)
 	var getUserResponse GetUserResponse
 	json.Unmarshal(body, &getUserResponse)
+	address, err := gmtoken.ConvertKeyToAddress(s.privateKey)
+	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "mike", getUserResponse.Name)
-	assert.Equal(s.T(), 100, getUserResponse.GmtokenBalance)
+	assert.Equal(s.T(), address.Hex(), getUserResponse.Address)
 }
 
 func (s *UserSuite) Test_GetUser_ByInvalidToken() {
 	s.ctx.Request = httptest.NewRequest("GET", "/user/get", nil)
 	s.ctx.Request.Header.Set("Content-Type", "application/json")
-	s.ctx.Request.Header.Set("x-token", "InvalidToken")
+	s.ctx.Request.Header.Set("x-token", s.token+"InvalidToken")
 
 	s.uapi.GetUser(s.ctx)
 
@@ -123,7 +145,6 @@ func (s *UserSuite) Test_GetUser_ByInvalidToken() {
 }
 
 func (s *UserSuite) Test_UpdateUser() {
-	s.SetToken()
 	s.ctx.Request = httptest.NewRequest("PUT", "/user/update", strings.NewReader(`{"name":"wang"}`))
 	s.ctx.Request.Header.Set("Content-Type", "application/json")
 	s.ctx.Request.Header.Set("x-token", s.token)
@@ -131,9 +152,7 @@ func (s *UserSuite) Test_UpdateUser() {
 	s.uapi.UpdateUser(s.ctx)
 
 	assert.Equal(s.T(), 200, s.recorder.Code)
-	userId, err := s.auth.GetUserId(s.ctx)
-	assert.Nil(s.T(), err)
-	user, err := s.db.GetUser(userId)
+	user, err := s.db.GetUser(s.userId)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), "wang", user.Name)
 }
@@ -141,7 +160,7 @@ func (s *UserSuite) Test_UpdateUser() {
 func (s *UserSuite) Test_UpdateUser_ByInvalidToken() {
 	s.ctx.Request = httptest.NewRequest("PUT", "/user/update", strings.NewReader(`{"name":"wang"}`))
 	s.ctx.Request.Header.Set("Content-Type", "application/json")
-	s.ctx.Request.Header.Set("x-token", "InvalidToken")
+	s.ctx.Request.Header.Set("x-token", s.token+"InvalidToken")
 
 	s.uapi.UpdateUser(s.ctx)
 

--- a/auth/authentication.go
+++ b/auth/authentication.go
@@ -19,7 +19,7 @@ func NewAuth(config *config.Config) *Auth {
 }
 
 // jwtトークンを照合する
-func (a *Auth) verifyToken(tokenString string) (*jwt.Token, error) {
+func (a *Auth) VerifyToken(tokenString string) (*jwt.Token, error) {
 	// 秘密鍵を取得
 	signBytes, err := ioutil.ReadFile(a.Idrsa)
 	if err != nil {

--- a/auth/util.go
+++ b/auth/util.go
@@ -9,7 +9,7 @@ import (
 // トークンからユーザID情報を取り出し、返す
 func (a *Auth) GetUserId(ctx *gin.Context) (string, error) {
 	tokenString := ctx.Request.Header.Get("x-token")
-	token, err := a.verifyToken(tokenString)
+	token, err := a.VerifyToken(tokenString)
 	if err != nil {
 		return "", err
 	}

--- a/database/character.go
+++ b/database/character.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"fmt"
 	"game-api-gin/model"
 )
 
@@ -28,7 +29,13 @@ func (d *GormDatabase) GetCharacterInfos(gacha_id int) ([]model.CharacterInfo, e
 		Joins("join characters on gacha_characters.character_id = characters.id").
 		Joins("join rarities on gacha_characters.rarity_id = rarities.id").
 		Where("gacha_id = ?", gacha_id).Scan(&characterInfos).Error
-	return characterInfos, err
+	if err != nil {
+		return []model.CharacterInfo{}, err
+	} else if len(characterInfos) == 0 {
+		return []model.CharacterInfo{}, fmt.Errorf("no data")
+	} else {
+		return characterInfos, err
+	}
 }
 
 // user_charactersテーブルからユーザIDが引数user_idのデータを取得

--- a/database/character_test.go
+++ b/database/character_test.go
@@ -40,11 +40,27 @@ func (s *DatabaseSuite) TestGetCharacterInfos() {
 	for _, v := range actualCharacterInfos01 {
 		actualSet01.Add(v)
 	}
-	var expectedCharacterInfos01 []model.CharacterInfo
-	s.db.DB.Table("gacha_characters").Select("gacha_characters.gacha_character_id, characters.character_name, rarities.weight").
-		Joins("join characters on gacha_characters.character_id = characters.id").
-		Joins("join rarities on gacha_characters.rarity_id = rarities.id").
-		Where("gacha_id = ?", 1).Scan(&expectedCharacterInfos01)
+	var expectedCharacterInfos01 [10]model.CharacterInfo
+	expectedCharacterInfos01[0] =
+		model.CharacterInfo{GachaCharacterID: "0d390f6b-5197-11ec-830e-a0c58933fdce", CharacterName: "Mercury", Weight: 1}
+	expectedCharacterInfos01[1] =
+		model.CharacterInfo{GachaCharacterID: "0d39f724-5197-11ec-830e-a0c58933fdce", CharacterName: "Venus", Weight: 5}
+	expectedCharacterInfos01[2] =
+		model.CharacterInfo{GachaCharacterID: "0d3aeef4-5197-11ec-830e-a0c58933fdce", CharacterName: "Earth", Weight: 5}
+	expectedCharacterInfos01[3] =
+		model.CharacterInfo{GachaCharacterID: "0d3c07d8-5197-11ec-830e-a0c58933fdce", CharacterName: "Mars", Weight: 5}
+	expectedCharacterInfos01[4] =
+		model.CharacterInfo{GachaCharacterID: "0d3cf0ad-5197-11ec-830e-a0c58933fdce", CharacterName: "Jupiter", Weight: 14}
+	expectedCharacterInfos01[5] =
+		model.CharacterInfo{GachaCharacterID: "0d3df5e3-5197-11ec-830e-a0c58933fdce", CharacterName: "Saturn", Weight: 14}
+	expectedCharacterInfos01[6] =
+		model.CharacterInfo{GachaCharacterID: "0d3ecd91-5197-11ec-830e-a0c58933fdce", CharacterName: "Uranus", Weight: 14}
+	expectedCharacterInfos01[7] =
+		model.CharacterInfo{GachaCharacterID: "0d3fea83-5197-11ec-830e-a0c58933fdce", CharacterName: "Neptune", Weight: 14}
+	expectedCharacterInfos01[8] =
+		model.CharacterInfo{GachaCharacterID: "0d40d0ae-5197-11ec-830e-a0c58933fdce", CharacterName: "Pluto", Weight: 14}
+	expectedCharacterInfos01[9] =
+		model.CharacterInfo{GachaCharacterID: "0d41b476-5197-11ec-830e-a0c58933fdce", CharacterName: "Sun", Weight: 14}
 	expectedSet01 := mapset.NewSet()
 	for _, v := range expectedCharacterInfos01 {
 		expectedSet01.Add(v)
@@ -57,11 +73,27 @@ func (s *DatabaseSuite) TestGetCharacterInfos() {
 	for _, v := range actualCharacterInfos02 {
 		actualSet02.Add(v)
 	}
-	var expectedCharacterInfos02 []model.CharacterInfo
-	s.db.DB.Table("gacha_characters").Select("gacha_characters.gacha_character_id, characters.character_name, rarities.weight").
-		Joins("join characters on gacha_characters.character_id = characters.id").
-		Joins("join rarities on gacha_characters.rarity_id = rarities.id").
-		Where("gacha_id = ?", 2).Scan(&expectedCharacterInfos02)
+	var expectedCharacterInfos02 [10]model.CharacterInfo
+	expectedCharacterInfos02[0] =
+		model.CharacterInfo{GachaCharacterID: "0d42a9a3-5197-11ec-830e-a0c58933fdce", CharacterName: "Mercury", Weight: 14}
+	expectedCharacterInfos02[1] =
+		model.CharacterInfo{GachaCharacterID: "0d437909-5197-11ec-830e-a0c58933fdce", CharacterName: "Venus", Weight: 14}
+	expectedCharacterInfos02[2] =
+		model.CharacterInfo{GachaCharacterID: "0d445545-5197-11ec-830e-a0c58933fdce", CharacterName: "Earth", Weight: 14}
+	expectedCharacterInfos02[3] =
+		model.CharacterInfo{GachaCharacterID: "0d453701-5197-11ec-830e-a0c58933fdce", CharacterName: "Mars", Weight: 1}
+	expectedCharacterInfos02[4] =
+		model.CharacterInfo{GachaCharacterID: "0d460f79-5197-11ec-830e-a0c58933fdce", CharacterName: "Jupiter", Weight: 5}
+	expectedCharacterInfos02[5] =
+		model.CharacterInfo{GachaCharacterID: "0d474188-5197-11ec-830e-a0c58933fdce", CharacterName: "Saturn", Weight: 5}
+	expectedCharacterInfos02[6] =
+		model.CharacterInfo{GachaCharacterID: "0d4826b4-5197-11ec-830e-a0c58933fdce", CharacterName: "Uranus", Weight: 5}
+	expectedCharacterInfos02[7] =
+		model.CharacterInfo{GachaCharacterID: "0d48f4d8-5197-11ec-830e-a0c58933fdce", CharacterName: "Neptune", Weight: 14}
+	expectedCharacterInfos02[8] =
+		model.CharacterInfo{GachaCharacterID: "0d49ed9c-5197-11ec-830e-a0c58933fdce", CharacterName: "Pluto", Weight: 14}
+	expectedCharacterInfos02[9] =
+		model.CharacterInfo{GachaCharacterID: "0d4abc80-5197-11ec-830e-a0c58933fdce", CharacterName: "Sun", Weight: 14}
 	expectedSet02 := mapset.NewSet()
 	for _, v := range expectedCharacterInfos02 {
 		expectedSet02.Add(v)
@@ -74,11 +106,27 @@ func (s *DatabaseSuite) TestGetCharacterInfos() {
 	for _, v := range actualCharacterInfos03 {
 		actualSet03.Add(v)
 	}
-	var expectedCharacterInfos03 []model.CharacterInfo
-	s.db.DB.Table("gacha_characters").Select("gacha_characters.gacha_character_id, characters.character_name, rarities.weight").
-		Joins("join characters on gacha_characters.character_id = characters.id").
-		Joins("join rarities on gacha_characters.rarity_id = rarities.id").
-		Where("gacha_id = ?", 3).Scan(&expectedCharacterInfos03)
+	var expectedCharacterInfos03 [10]model.CharacterInfo
+	expectedCharacterInfos03[0] =
+		model.CharacterInfo{GachaCharacterID: "0d4b8cc9-5197-11ec-830e-a0c58933fdce", CharacterName: "Mercury", Weight: 14}
+	expectedCharacterInfos03[1] =
+		model.CharacterInfo{GachaCharacterID: "0d4cc775-5197-11ec-830e-a0c58933fdce", CharacterName: "Venus", Weight: 14}
+	expectedCharacterInfos03[2] =
+		model.CharacterInfo{GachaCharacterID: "0d4d8d92-5197-11ec-830e-a0c58933fdce", CharacterName: "Earth", Weight: 14}
+	expectedCharacterInfos03[3] =
+		model.CharacterInfo{GachaCharacterID: "0d4f0347-5197-11ec-830e-a0c58933fdce", CharacterName: "Mars", Weight: 14}
+	expectedCharacterInfos03[4] =
+		model.CharacterInfo{GachaCharacterID: "0d4fc8b3-5197-11ec-830e-a0c58933fdce", CharacterName: "Jupiter", Weight: 14}
+	expectedCharacterInfos03[5] =
+		model.CharacterInfo{GachaCharacterID: "0d509e02-5197-11ec-830e-a0c58933fdce", CharacterName: "Saturn", Weight: 14}
+	expectedCharacterInfos03[6] =
+		model.CharacterInfo{GachaCharacterID: "0d51acef-5197-11ec-830e-a0c58933fdce", CharacterName: "Uranus", Weight: 1}
+	expectedCharacterInfos03[7] =
+		model.CharacterInfo{GachaCharacterID: "0d527e11-5197-11ec-830e-a0c58933fdce", CharacterName: "Neptune", Weight: 5}
+	expectedCharacterInfos03[8] =
+		model.CharacterInfo{GachaCharacterID: "0d5362ad-5197-11ec-830e-a0c58933fdce", CharacterName: "Pluto", Weight: 5}
+	expectedCharacterInfos03[9] =
+		model.CharacterInfo{GachaCharacterID: "0d544ad9-5197-11ec-830e-a0c58933fdce", CharacterName: "Sun", Weight: 5}
 	expectedSet03 := mapset.NewSet()
 	for _, v := range expectedCharacterInfos03 {
 		expectedSet03.Add(v)
@@ -93,10 +141,67 @@ func (s *DatabaseSuite) TestGetAllCharacters() {
 	for _, v := range actualAllCharacterInfos {
 		actualSet.Add(v)
 	}
-	var expectedAllCharacterInfos []model.CharacterInfo
-	s.db.DB.Table("gacha_characters").Select("gacha_characters.gacha_character_id, characters.character_name, rarities.weight").
-		Joins("join characters on gacha_characters.character_id = characters.id").
-		Joins("join rarities on gacha_characters.rarity_id = rarities.id").Scan(&expectedAllCharacterInfos)
+	var expectedAllCharacterInfos [30]model.CharacterInfo
+	expectedAllCharacterInfos[0] =
+		model.CharacterInfo{GachaCharacterID: "0d390f6b-5197-11ec-830e-a0c58933fdce", CharacterName: "Mercury", Weight: 1}
+	expectedAllCharacterInfos[1] =
+		model.CharacterInfo{GachaCharacterID: "0d39f724-5197-11ec-830e-a0c58933fdce", CharacterName: "Venus", Weight: 5}
+	expectedAllCharacterInfos[2] =
+		model.CharacterInfo{GachaCharacterID: "0d3aeef4-5197-11ec-830e-a0c58933fdce", CharacterName: "Earth", Weight: 5}
+	expectedAllCharacterInfos[3] =
+		model.CharacterInfo{GachaCharacterID: "0d3c07d8-5197-11ec-830e-a0c58933fdce", CharacterName: "Mars", Weight: 5}
+	expectedAllCharacterInfos[4] =
+		model.CharacterInfo{GachaCharacterID: "0d3cf0ad-5197-11ec-830e-a0c58933fdce", CharacterName: "Jupiter", Weight: 14}
+	expectedAllCharacterInfos[5] =
+		model.CharacterInfo{GachaCharacterID: "0d3df5e3-5197-11ec-830e-a0c58933fdce", CharacterName: "Saturn", Weight: 14}
+	expectedAllCharacterInfos[6] =
+		model.CharacterInfo{GachaCharacterID: "0d3ecd91-5197-11ec-830e-a0c58933fdce", CharacterName: "Uranus", Weight: 14}
+	expectedAllCharacterInfos[7] =
+		model.CharacterInfo{GachaCharacterID: "0d3fea83-5197-11ec-830e-a0c58933fdce", CharacterName: "Neptune", Weight: 14}
+	expectedAllCharacterInfos[8] =
+		model.CharacterInfo{GachaCharacterID: "0d40d0ae-5197-11ec-830e-a0c58933fdce", CharacterName: "Pluto", Weight: 14}
+	expectedAllCharacterInfos[9] =
+		model.CharacterInfo{GachaCharacterID: "0d41b476-5197-11ec-830e-a0c58933fdce", CharacterName: "Sun", Weight: 14}
+	expectedAllCharacterInfos[10] =
+		model.CharacterInfo{GachaCharacterID: "0d42a9a3-5197-11ec-830e-a0c58933fdce", CharacterName: "Mercury", Weight: 14}
+	expectedAllCharacterInfos[11] =
+		model.CharacterInfo{GachaCharacterID: "0d437909-5197-11ec-830e-a0c58933fdce", CharacterName: "Venus", Weight: 14}
+	expectedAllCharacterInfos[12] =
+		model.CharacterInfo{GachaCharacterID: "0d445545-5197-11ec-830e-a0c58933fdce", CharacterName: "Earth", Weight: 14}
+	expectedAllCharacterInfos[13] =
+		model.CharacterInfo{GachaCharacterID: "0d453701-5197-11ec-830e-a0c58933fdce", CharacterName: "Mars", Weight: 1}
+	expectedAllCharacterInfos[14] =
+		model.CharacterInfo{GachaCharacterID: "0d460f79-5197-11ec-830e-a0c58933fdce", CharacterName: "Jupiter", Weight: 5}
+	expectedAllCharacterInfos[15] =
+		model.CharacterInfo{GachaCharacterID: "0d474188-5197-11ec-830e-a0c58933fdce", CharacterName: "Saturn", Weight: 5}
+	expectedAllCharacterInfos[16] =
+		model.CharacterInfo{GachaCharacterID: "0d4826b4-5197-11ec-830e-a0c58933fdce", CharacterName: "Uranus", Weight: 5}
+	expectedAllCharacterInfos[17] =
+		model.CharacterInfo{GachaCharacterID: "0d48f4d8-5197-11ec-830e-a0c58933fdce", CharacterName: "Neptune", Weight: 14}
+	expectedAllCharacterInfos[18] =
+		model.CharacterInfo{GachaCharacterID: "0d49ed9c-5197-11ec-830e-a0c58933fdce", CharacterName: "Pluto", Weight: 14}
+	expectedAllCharacterInfos[19] =
+		model.CharacterInfo{GachaCharacterID: "0d4abc80-5197-11ec-830e-a0c58933fdce", CharacterName: "Sun", Weight: 14}
+	expectedAllCharacterInfos[20] =
+		model.CharacterInfo{GachaCharacterID: "0d4b8cc9-5197-11ec-830e-a0c58933fdce", CharacterName: "Mercury", Weight: 14}
+	expectedAllCharacterInfos[21] =
+		model.CharacterInfo{GachaCharacterID: "0d4cc775-5197-11ec-830e-a0c58933fdce", CharacterName: "Venus", Weight: 14}
+	expectedAllCharacterInfos[22] =
+		model.CharacterInfo{GachaCharacterID: "0d4d8d92-5197-11ec-830e-a0c58933fdce", CharacterName: "Earth", Weight: 14}
+	expectedAllCharacterInfos[23] =
+		model.CharacterInfo{GachaCharacterID: "0d4f0347-5197-11ec-830e-a0c58933fdce", CharacterName: "Mars", Weight: 14}
+	expectedAllCharacterInfos[24] =
+		model.CharacterInfo{GachaCharacterID: "0d4fc8b3-5197-11ec-830e-a0c58933fdce", CharacterName: "Jupiter", Weight: 14}
+	expectedAllCharacterInfos[25] =
+		model.CharacterInfo{GachaCharacterID: "0d509e02-5197-11ec-830e-a0c58933fdce", CharacterName: "Saturn", Weight: 14}
+	expectedAllCharacterInfos[26] =
+		model.CharacterInfo{GachaCharacterID: "0d51acef-5197-11ec-830e-a0c58933fdce", CharacterName: "Uranus", Weight: 1}
+	expectedAllCharacterInfos[27] =
+		model.CharacterInfo{GachaCharacterID: "0d527e11-5197-11ec-830e-a0c58933fdce", CharacterName: "Neptune", Weight: 5}
+	expectedAllCharacterInfos[28] =
+		model.CharacterInfo{GachaCharacterID: "0d5362ad-5197-11ec-830e-a0c58933fdce", CharacterName: "Pluto", Weight: 5}
+	expectedAllCharacterInfos[29] =
+		model.CharacterInfo{GachaCharacterID: "0d544ad9-5197-11ec-830e-a0c58933fdce", CharacterName: "Sun", Weight: 5}
 	expectedSet := mapset.NewSet()
 	for _, v := range expectedAllCharacterInfos {
 		expectedSet.Add(v)

--- a/database/user.go
+++ b/database/user.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"fmt"
 	"game-api-gin/model"
 )
 
@@ -16,11 +17,24 @@ func (d *GormDatabase) GetUser(userId string) (model.User, error) {
 	var user model.User
 	// SELECT * FROM `users` WHERE user_id = '95daec2b-287c-4358-ba6f-5c29e1c3cbdf'
 	err := d.DB.Where("user_id = ?", userId).Find(&user).Error
-	return user, err
+	if err != nil {
+		return model.User{}, err
+	} else if (user == model.User{}) {
+		return model.User{}, fmt.Errorf("no data")
+	} else {
+		return user, err
+	}
 }
 
 // usersテーブルからユーザIDが引数userIdのユーザの情報を、引数userのものに更新
 func (d *GormDatabase) UpdateUser(user model.User, userId string) error {
 	// UPDATE `users` SET `name`='bbb' WHERE user_id = '95daec2b-287c-4358-ba6f-5c29e1c3cbdf'
-	return d.DB.Model(&user).Where("user_id = ?", userId).Update("name", user.Name).Error
+	err := d.DB.Model(&user).Where("user_id = ?", userId).Update("name", user.Name).Error
+	if err != nil {
+		return err
+	} else if (user == model.User{}) {
+		return fmt.Errorf("no data")
+	} else {
+		return err
+	}
 }

--- a/database/user_test.go
+++ b/database/user_test.go
@@ -10,8 +10,7 @@ import (
 
 func (s *DatabaseSuite) TestUser() {
 	user, err := s.db.GetUser("asdf")
-	require.NoError(s.T(), err)
-	assert.Equal(s.T(), model.User{}, user)
+	assert.Error(s.T(), err)
 
 	userId, err := util.CreateUUId()
 	require.NoError(s.T(), err)

--- a/gmtoken/gmtokentx.go
+++ b/gmtoken/gmtokentx.go
@@ -71,7 +71,7 @@ func NewGmtokenTx(config *config.Config) (*GmtokenTx, error) {
 }
 
 // 16進数の秘密鍵文字列をイーサリアムアドレスに変換
-func convertKeyToAddress(hexkey string) (common.Address, error) {
+func ConvertKeyToAddress(hexkey string) (common.Address, error) {
 	// 16進数の秘密鍵文字列を読み込む
 	privateKey, err := crypto.HexToECDSA(hexkey)
 	if err != nil {
@@ -92,7 +92,7 @@ func convertKeyToAddress(hexkey string) (common.Address, error) {
 // コントラクトからそのアドレスのゲームトークン残高を取り出す
 // アドレスと残高を返す
 func (g *GmtokenTx) GetAddressBalance(hexkey string) (common.Address, int, error) {
-	address, err := convertKeyToAddress(hexkey)
+	address, err := ConvertKeyToAddress(hexkey)
 	if err != nil {
 		return common.Address{}, 0, err
 	}
@@ -109,7 +109,7 @@ func (g *GmtokenTx) GetAddressBalance(hexkey string) (common.Address, int, error
 // トランザクションの送信者は、minter_private_key.txtの秘密鍵から生成されるアドレスである
 func (g *GmtokenTx) TransferEth(val int64, hexkey string) error {
 	// 16進数の秘密鍵文字列をアドレスに変換
-	address, err := convertKeyToAddress(hexkey)
+	address, err := ConvertKeyToAddress(hexkey)
 	if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func (g *GmtokenTx) TransferEth(val int64, hexkey string) error {
 		return err
 	}
 	// 秘密鍵からアドレスを生成
-	fromAddress, err := convertKeyToAddress(string(privateKeyBytes))
+	fromAddress, err := ConvertKeyToAddress(string(privateKeyBytes))
 	if err != nil {
 		return err
 	}
@@ -170,7 +170,7 @@ func (g *GmtokenTx) TransferEth(val int64, hexkey string) error {
 // トランザクションの送信者は、minter_private_key.txtの秘密鍵から生成されるアドレスである
 func (g *GmtokenTx) MintGmtoken(val int, hexkey string) error {
 	// 16進数の秘密鍵文字列をアドレスに変換
-	address, err := convertKeyToAddress(hexkey)
+	address, err := ConvertKeyToAddress(hexkey)
 	if err != nil {
 		return err
 	}
@@ -184,7 +184,7 @@ func (g *GmtokenTx) MintGmtoken(val int, hexkey string) error {
 		return err
 	}
 	// 秘密鍵からアドレスを生成
-	fromAddress, err := convertKeyToAddress(string(privateKeyBytes))
+	fromAddress, err := ConvertKeyToAddress(string(privateKeyBytes))
 	if err != nil {
 		return err
 	}
@@ -272,7 +272,7 @@ func (g *GmtokenTx) BurnGmtoken(val int, hexkey string) error {
 		return err
 	}
 	// 16進数の秘密鍵文字列をアドレスに変換
-	address, err := convertKeyToAddress(hexkey)
+	address, err := ConvertKeyToAddress(hexkey)
 	if err != nil {
 		return err
 	}

--- a/mysql/ddl.sql
+++ b/mysql/ddl.sql
@@ -58,38 +58,68 @@ CREATE TABLE IF NOT EXISTS `game_user`.`gacha_characters`(
   `HP` INT NOT NULL
 );
 
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 1, 1, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 2, 2, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 3, 2, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 4, 2, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 5, 3, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 6, 3, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 7, 3, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 8, 3, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 9, 3, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 1, 10, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d390f6b-5197-11ec-830e-a0c58933fdce", 1, 1, 1, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d39f724-5197-11ec-830e-a0c58933fdce", 1, 2, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d3aeef4-5197-11ec-830e-a0c58933fdce", 1, 3, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d3c07d8-5197-11ec-830e-a0c58933fdce", 1, 4, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d3cf0ad-5197-11ec-830e-a0c58933fdce", 1, 5, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d3df5e3-5197-11ec-830e-a0c58933fdce", 1, 6, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d3ecd91-5197-11ec-830e-a0c58933fdce", 1, 7, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d3fea83-5197-11ec-830e-a0c58933fdce", 1, 8, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d40d0ae-5197-11ec-830e-a0c58933fdce", 1, 9, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d41b476-5197-11ec-830e-a0c58933fdce", 1, 10, 3, 0);
 
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 1, 3, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 2, 3, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 3, 3, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 4, 1, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 5, 2, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 6, 2, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 7, 2, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 8, 3, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 9, 3, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 2, 10, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d42a9a3-5197-11ec-830e-a0c58933fdce", 2, 1, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d437909-5197-11ec-830e-a0c58933fdce", 2, 2, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d445545-5197-11ec-830e-a0c58933fdce", 2, 3, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d453701-5197-11ec-830e-a0c58933fdce", 2, 4, 1, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d460f79-5197-11ec-830e-a0c58933fdce", 2, 5, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d474188-5197-11ec-830e-a0c58933fdce", 2, 6, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d4826b4-5197-11ec-830e-a0c58933fdce", 2, 7, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d48f4d8-5197-11ec-830e-a0c58933fdce", 2, 8, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d49ed9c-5197-11ec-830e-a0c58933fdce", 2, 9, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d4abc80-5197-11ec-830e-a0c58933fdce", 2, 10, 3, 0);
 
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 1, 3, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 2, 3, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 3, 3, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 4, 3, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 5, 3, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 6, 3, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 7, 1, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 8, 2, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 9, 2, 0);
-INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) VALUES (UUID(), 3, 10, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d4b8cc9-5197-11ec-830e-a0c58933fdce", 3, 1, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d4cc775-5197-11ec-830e-a0c58933fdce", 3, 2, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d4d8d92-5197-11ec-830e-a0c58933fdce", 3, 3, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d4f0347-5197-11ec-830e-a0c58933fdce", 3, 4, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d4fc8b3-5197-11ec-830e-a0c58933fdce", 3, 5, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d509e02-5197-11ec-830e-a0c58933fdce", 3, 6, 3, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d51acef-5197-11ec-830e-a0c58933fdce", 3, 7, 1, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d527e11-5197-11ec-830e-a0c58933fdce", 3, 8, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d5362ad-5197-11ec-830e-a0c58933fdce", 3, 9, 2, 0);
+INSERT INTO gacha_characters(gacha_character_id, gacha_id, character_id, rarity_id, HP) 
+VALUES ("0d544ad9-5197-11ec-830e-a0c58933fdce", 3, 10, 2, 0);
 
 CREATE VIEW character_HP AS
 SELECT gacha_characters.gacha_character_id, rarities.HPup + characters.HP AS HP

--- a/test/test.go
+++ b/test/test.go
@@ -1,0 +1,10 @@
+package test
+
+func Contains(set []string, element string) bool {
+	for _, v := range set {
+		if element == v {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## 変更の概要

apiディレクトリ内のuserテストにおいて、CreateUserリクエストの後にそれぞれの関数のテストを行っていたが、これをCreateUserリクエストをせずにテストを行うように変更した。これにより、CreateUser、GetUser、UpdateUserの三つの関数において、単体テストを行った形となった。同様に、gachaとcharacterテストにおいても、DrawGachaリクエストを行った後にGetCharacterList関数のテストを行うのではなく、二つの関数テストを独立させて単体テストとなるようにコードを修正した。
また、databaseディレクトリ内のcharacterテストにおいて、関数内のsql文と同じsql文をテストコードに書いていたが、これではテストとして成立しないため、テストの期待値としてddl.sqlに記述した値を用いるようにコードを変更した。